### PR TITLE
Initial release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+* 
+
+entrypoint.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 * 
 
-entrypoint.sh
+!entrypoint.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+* Initial release.
+* Support running as a non-root user.
+* The `SYNCDIR` environment variable is now required and the location must be writable by the `s3sync` user.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Intellection/sre

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,27 @@
 FROM alpine:3.17
 
-# Environment
-ENV AWS_DEFAULT_REGION=us-east-1
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache \
+      aws-cli \
+      bash \
+      dcron \
+      libcap \
+      inotify-tools \
+      tini
 
-# Install packages
-RUN apk --no-cache add aws-cli bash findutils groff less tini inotify-tools
+ENV S3_SYNC_USER="s3sync"
+ENV S3_SYNC_HOME="/home/${S3_SYNC_USER}"
+RUN addgroup -g "9999" "${S3_SYNC_USER}" && \
+    adduser -S -D -u "9999" -G "${S3_SYNC_USER}" "${S3_SYNC_USER}"
 
-# Entrypoint
+RUN touch /etc/crontabs/${S3_SYNC_USER} && \
+    chown ${S3_SYNC_USER}:${S3_SYNC_USER} /etc/crontabs/${S3_SYNC_USER} && \
+    chown ${S3_SYNC_USER}:${S3_SYNC_USER} /usr/sbin/crond && \
+    setcap cap_setgid=ep /usr/sbin/crond
+
 COPY entrypoint.sh /
-ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]
+
+USER ${S3_SYNC_USER}:${S3_SYNC_USER}
+
+ENTRYPOINT ["tini", "--", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM alpine:20230208
-LABEL maintainer "Vlad Ghinea vlad@ghn.me"
+FROM alpine:3.17
 
 # Environment
 ENV AWS_DEFAULT_REGION=us-east-1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:20230208
+LABEL maintainer "Vlad Ghinea vlad@ghn.me"
+
+# Environment
+ENV AWS_DEFAULT_REGION=us-east-1
+
+# Install packages
+RUN apk --no-cache add aws-cli bash findutils groff less tini inotify-tools
+
+# Entrypoint
+COPY entrypoint.sh /
+ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The image supports the following commands:
 | AWS_SECRET_ACCESS_KEY | Yes | (or functional IAM profile) |
 | AWS_DEFAULT_REGION | Yes | (or functional IAM profile) |
 | S3PATH | Yes | the S3 synchronize location (ex: `s3://mybucket/myprefix`) |
-| SYNCDIR | No | the local synchronize location (defaults to `/sync`) |
+| SYNCDIR | Yes | the local synchronize location |
 | AWS_S3_SSE | No | use S3 Server Side Encryption; it can be `false` for no encryption, `aes256` or `true` for Server-Side Encryption with Amazon S3-Managed Keys (SSE-S3) and `kms` for Server-Side Encryption with AWS KMS-Managed Keys (SSE-KMS) (defaults to `false`). For more information refer to <https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html> (Note: Server-Side Encryption with Customer-Provided Keys (SSE-C) is not currently supported) |
 | AWS_S3_SSE_KMS_KEY_ID | No | The AWS KMS key ID that should be used to server-side encrypt the object in S3 (only available if use in conjunction with `AWS_S3_SSE`) |
 | CRON_TIME | No | a valid cron expression (ex: `CRON_TIME='0 */6 * * *'` runs every 6 hours; defaults to hourly) |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ The image supports the following commands:
 | INITIAL_DOWNLOAD | No | whether to download files initially (defaults to `true`); this will only download the files if the directory is empty. Set this to `force` to skip this check |
 | SYNCEXTRA | No | add extra options to aws-cli sync command |
 
-
 ## Usage
 
 ### Download files and exit
@@ -90,7 +89,7 @@ docker run -d \
   zappi/s3sync
 ```
 
-Notes:
+**Notes:**
 
 * The `--rm` flag in the "Download files and exit" command removes the container after it exits, avoiding a build-up of stopped containers.
 * In "Upload files and exit" command, the `upload` argument tells the container to upload files before exiting.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The image supports the following commands:
 | AWS_SECRET_ACCESS_KEY | Yes | (or functional IAM profile) |
 | AWS_DEFAULT_REGION | Yes | (or functional IAM profile) |
 | S3PATH | Yes | the S3 synchronize location (ex: `s3://mybucket/myprefix`) |
-| SYNCDIR | Yes | the local synchronize location |
+| SYNCDIR | Yes | the local synchronize location (must be writable by the `s3sync` user) |
 | AWS_S3_SSE | No | use S3 Server Side Encryption; it can be `false` for no encryption, `aes256` or `true` for Server-Side Encryption with Amazon S3-Managed Keys (SSE-S3) and `kms` for Server-Side Encryption with AWS KMS-Managed Keys (SSE-KMS) (defaults to `false`). For more information refer to <https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html> (Note: Server-Side Encryption with Customer-Provided Keys (SSE-C) is not currently supported) |
 | AWS_S3_SSE_KMS_KEY_ID | No | The AWS KMS key ID that should be used to server-side encrypt the object in S3 (only available if use in conjunction with `AWS_S3_SSE`) |
 | CRON_TIME | No | a valid cron expression (ex: `CRON_TIME='0 */6 * * *'` runs every 6 hours; defaults to hourly) |

--- a/README.md
+++ b/README.md
@@ -1,0 +1,101 @@
+# S3 Sync
+
+This Docker container syncs a local directory to an AWS S3 bucket, allowing for easy backups and synchronization of data.
+
+If the specified local directory is empty, it performs an initial sync from the specified S3 bucket. Then, it syncs that directory with the specified S3 bucket. If the local directory was not empty to begin with, it skips the initial sync.
+
+This container is suitable for creating a recent backup copy of data in S3, which can then be easily retrieved when launching new nodes.
+
+Note: This container is designed for syncing files to S3 from a single node and is not recommended as a permanent backup solution.
+
+By default, the download location inside the container is set to /sync. However, this can be changed via the SYNCDIR environment variable.
+
+## Commands
+
+The image supports the following commands:
+
+* `download`: (default) downloads the files and exits
+* `upload`: uploads the files and exits
+* `sync`: uses inotify to upload a directory to S3 when files change (see `SYNCDIR`)
+* `periodic_upload`: sets up a cron job to upload files to S3 periodically (see `CRON_TIME` and `INITIAL_DOWNLOAD`)
+* `periodic_download`: sets up a cron job to download files from S3 periodically (see `CRON_TIME` and `INITIAL_DOWNLOAD`)
+
+## Environment variables
+
+| Environment variables | Required | Description |
+| --- | --- | --- |
+| AWS_ACCESS_KEY_ID | Yes | (or functional IAM profile) |
+| AWS_SECRET_ACCESS_KEY | Yes | (or functional IAM profile) |
+| AWS_DEFAULT_REGION | Yes | (or functional IAM profile) |
+| S3PATH | Yes | the S3 synchronize location (ex: `s3://mybucket/myprefix`) |
+| SYNCDIR | No | the local synchronize location (defaults to `/sync`) |
+| AWS_S3_SSE | No | use S3 Server Side Encryption; it can be `false` for no encryption, `aes256` or `true` for Server-Side Encryption with Amazon S3-Managed Keys (SSE-S3) and `kms` for Server-Side Encryption with AWS KMS-Managed Keys (SSE-KMS) (defaults to `false`). For more information refer to <https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html> (Note: Server-Side Encryption with Customer-Provided Keys (SSE-C) is not currently supported) |
+| AWS_S3_SSE_KMS_KEY_ID | No | The AWS KMS key ID that should be used to server-side encrypt the object in S3 (only available if use in conjunction with `AWS_S3_SSE`) |
+| CRON_TIME | No | a valid cron expression (ex: `CRON_TIME='0 */6 * * *'` runs every 6 hours; defaults to hourly) |
+| INITIAL_DOWNLOAD | No | whether to download files initially (defaults to `true`); this will only download the files if the directory is empty. Set this to `force` to skip this check |
+| SYNCEXTRA | No | add extra options to aws-cli sync command |
+
+
+## Usage
+
+### Download files and exit
+
+```console
+docker run --rm \
+  -e S3PATH='s3://mybucket/myprefix' \
+  zappi/s3sync
+```
+
+### Upload files and exit
+
+```console
+docker run --rm \
+  -e S3PATH='s3://mybucket/myprefix' \
+  zappi/s3sync upload
+```
+
+### Upload files periodically (every 6 hours)
+
+```console
+docker run -d \
+  -e S3PATH='s3://mybucket/myprefix' \
+  -e CRON_TIME='0 */6 * * *' \
+  zappi/s3sync cron
+```
+
+### Watch local directory
+
+```console
+docker run -d \
+  -e S3PATH='s3://mybucket/myprefix' \
+  zappi/s3sync sync
+```
+
+### Watch the specified local directory (host mount)
+
+```console
+docker run -d \
+  -e S3PATH='s3://mybucket/myprefix' \
+  -e SYNCDIR='/mydir' \
+  -v $(pwd):/mydir \
+  zappi/s3sync sync
+```
+
+### External AWS credentials
+
+```console
+docker run -d \
+  -e S3PATH='s3://mybucket/myprefix' \
+  -v ~/.aws:/root/.aws:ro \
+  zappi/s3sync
+```
+
+Notes:
+
+* The `--rm` flag in the "Download files and exit" command removes the container after it exits, avoiding a build-up of stopped containers.
+* In "Upload files and exit" command, the `upload` argument tells the container to upload files before exiting.
+* In "Watch the specified local directory (host mount)" command, `$(pwd)` is used to specify the current directory as the one to sync. Change this to the appropriate directory for your use case.
+
+## Credits
+
+This image is based heavily on the work of @vladgh's [s3sync](https://github.com/vladgh/docker_base_images/blob/main/s3sync) base image.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,4 @@ services:
       CRON_TIME: "* * * * *"
       INITIAL_DOWNLOAD: "true"
       S3PATH: "s3://my-bucket/my-prefix"
-      SYNCDIR: "/data"
-    volumes:
-      - /data
+      SYNCDIR: "/tmp/data"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.9"
+services:
+  sync:
+    build: .
+    image: zappi/s3-sync
+    command: periodic_download
+    environment:
+      AWS_ACCESS_KEY_ID: ""
+      AWS_DEFAULT_REGION: ""
+      AWS_SECRET_ACCESS_KEY: ""
+      CRON_TIME: "* * * * *"
+      INITIAL_DOWNLOAD: "true"
+      S3PATH: "s3://my-bucket/my-prefix"
+      SYNCDIR: "/data"
+    volumes:
+      - /data

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# S3Sync Entry Point
+
+# Bash strict mode
+set -euo pipefail
+IFS=$'\n\t'
+
+# VARs
+S3PATH=${S3PATH:-}
+SYNCDIR="${SYNCDIR:-/sync}"
+AWS_S3_SSE="${AWS_S3_SSE:-false}"
+AWS_S3_SSE_KMS_KEY_ID="${AWS_S3_SSE_KMS_KEY_ID:-}"
+CRON_TIME="${CRON_TIME:-10 * * * *}"
+INITIAL_DOWNLOAD="${INITIAL_DOWNLOAD:-true}"
+SYNCEXTRA="${SYNCEXTRA:-}"
+
+# Log message
+log(){
+  echo "[$(date "+%Y-%m-%dT%H:%M:%S%z") - $(hostname)] ${*}"
+}
+
+# Sync files
+sync_files(){
+  local src dst sync_cmd
+  src="${1:-}"
+  dst="${2:-}"
+
+  sync_cmd="--no-progress --delete --exact-timestamps $SYNCEXTRA"
+
+  if [[ "$AWS_S3_SSE" == 'true' ]] || [[ "$AWS_S3_SSE" == 'aes256' ]]; then
+    s3_upload_cmd+=' --sse AES256'
+  elif [[ "$AWS_S3_SSE" == 'kms' ]]; then
+    s3_upload_cmd+=' --sse aws:kms'
+    if [[ -n "$AWS_S3_SSE_KMS_KEY_ID" ]]; then
+      s3_upload_cmd+=" --sse-kms-key-id ${AWS_S3_SSE_KMS_KEY_ID}"
+    fi
+  fi
+
+  if [[ ! "$dst" =~ s3:// ]]; then
+    mkdir -p "$dst" # Make sure directory exists
+  fi
+
+  log "Sync '${src}' to '${dst}'"
+  if ! eval aws s3 sync "$sync_cmd" "$src" "$dst"; then
+    log "Could not sync '${src}' to '${dst}'" >&2; exit 1
+  fi
+}
+
+# Download files
+download_files(){
+  sync_files "$S3PATH" "$SYNCDIR"
+}
+
+# Upload files
+upload_files(){
+  sync_files "$SYNCDIR" "$S3PATH"
+}
+
+# Run initial download
+initial_download(){
+  if [[ "$INITIAL_DOWNLOAD" == 'true' ]]; then
+    if [[ -d "$SYNCDIR" ]]; then
+      # directory exists
+      if [[ $(ls -A "$SYNCDIR" 2>/dev/null) ]]; then
+        # directory is not empty
+        log "${SYNCDIR} is not empty; skipping initial download"
+      else
+        # directory is empty
+      download_files
+      fi
+    else
+      # directory does not exist
+    download_files
+    fi
+  elif [[ "$INITIAL_DOWNLOAD" == 'force' ]]; then
+    download_files
+  fi
+}
+
+# Watch directory using inotify
+watch_directory(){
+  initial_download # Run initial download
+
+  log "Watching directory '${SYNCDIR}' for changes"
+  inotifywait \
+    --event create \
+    --event delete \
+    --event modify \
+    --event move \
+    --format "%e %w%f" \
+    --monitor \
+    --quiet \
+    --recursive \
+    "$SYNCDIR" |
+  while read -r changed
+  do
+    log "$changed"
+    upload_files
+  done
+}
+
+# Install cron job
+run_cron(){
+  local action="${1:-upload}"
+
+  # Run initial download
+  initial_download
+
+  log "Setup the cron job (${CRON_TIME})"
+  echo "${CRON_TIME} /entrypoint.sh ${action}" > /etc/crontabs/root
+  exec crond -f -l 6
+}
+
+# Main function
+main(){
+  if [[ ! "$S3PATH" =~ s3:// ]]; then
+    log 'No S3PATH specified' >&2; exit 1
+  fi
+
+  mkdir -p "$SYNCDIR" # Make sure directory exists
+
+  # Parse command line arguments
+  cmd="${1:-download}"
+  case "$cmd" in
+    download)
+      download_files
+      ;;
+    upload)
+      upload_files
+      ;;
+    sync)
+      watch_directory
+      ;;
+    periodic_upload)
+      run_cron upload
+      ;;
+    periodic_download)
+      run_cron download
+      ;;
+    *)
+      log "Unknown command: ${cmd}"; exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -109,7 +109,7 @@ run_cron(){
   log "Setup the cron job (${CRON_TIME})"
   echo "${CRON_TIME} /entrypoint.sh ${action} > /proc/1/fd/1 2>&1" > /etc/crontabs/${S3_SYNC_USER}
 
-  exec crond -f -l 6
+  exec crond -f -l 4
 }
 
 # Main function

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -107,7 +107,8 @@ run_cron(){
   initial_download
 
   log "Setup the cron job (${CRON_TIME})"
-  echo "${CRON_TIME} /entrypoint.sh ${action}" > /etc/crontabs/root
+  echo "${CRON_TIME} /entrypoint.sh ${action}" > /etc/crontabs/${S3_SYNC_USER}
+
   exec crond -f -l 6
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -107,7 +107,7 @@ run_cron(){
   initial_download
 
   log "Setup the cron job (${CRON_TIME})"
-  echo "${CRON_TIME} /entrypoint.sh ${action}" > /etc/crontabs/${S3_SYNC_USER}
+  echo "${CRON_TIME} /entrypoint.sh ${action} > /proc/1/fd/1 2>&1" > /etc/crontabs/${S3_SYNC_USER}
 
   exec crond -f -l 6
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ IFS=$'\n\t'
 
 # VARs
 S3PATH=${S3PATH:-}
-SYNCDIR="${SYNCDIR:-/sync}"
+SYNCDIR="${SYNCDIR:-}"
 AWS_S3_SSE="${AWS_S3_SSE:-false}"
 AWS_S3_SSE_KMS_KEY_ID="${AWS_S3_SSE_KMS_KEY_ID:-}"
 CRON_TIME="${CRON_TIME:-10 * * * *}"


### PR DESCRIPTION
Adds support for running [s3sync](https://github.com/vladgh/docker_base_images/tree/main/s3sync) as a non-root user. 

It includes modifications to the Dockerfile and related scripts to ensure that the necessary permissions are set correctly, allowing the image to be run with reduced privileges. This change improves the security and portability of the image, making it more accessible to a wider range of users and environments.

Credits go to @vladgh for basically everything.