### PR TITLE
[SRE-4346] Upgrade base image to `alpine:3.20.3`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test-docker-image
 on:
   pull_request:
     branches:
-      - 'master'
+      - 'main'
 
 env:
   IMAGE: zappi/s3-sync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0
+
+* Upgrade base image to `alpine:3.20.3`.
+
 ## 0.1.0
 
 * Initial release.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.20.3
 
 RUN apk update && \
     apk upgrade && \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # S3 Sync
 
+[![release-docker-image](https://github.com/Intellection/docker-s3-sync/actions/workflows/release.yml/badge.svg)](https://github.com/Intellection/docker-s3-sync/actions/workflows/release.yml) [![test-docker-image](https://github.com/Intellection/docker-s3-sync/actions/workflows/test.yml/badge.svg)](https://github.com/Intellection/docker-s3-sync/actions/workflows/test.yml)
+
 This Docker container syncs a local directory to an AWS S3 bucket, allowing for easy backups and synchronization of data.
 
 If the specified local directory is empty, it performs an initial sync from the specified S3 bucket. Then, it syncs that directory with the specified S3 bucket. If the local directory was not empty to begin with, it skips the initial sync.


### PR DESCRIPTION
As per the title. To note, I added test and release workflows on GitHub Actions in https://github.com/Intellection/docker-s3-sync/pull/2 adding support for multi-arch so this will be the first multi-arch release.